### PR TITLE
Add two attributes to GenerateFwTargets task

### DIFF
--- a/SIL.FwBuildTasks/GenerateFwTargetsTask.cs
+++ b/SIL.FwBuildTasks/GenerateFwTargetsTask.cs
@@ -10,11 +10,17 @@ namespace SIL.FieldWorks.Build.Tasks
 {
 	public class GenerateFwTargets : Task
 	{
+		[Required]
+		public string TimeoutValuesFilePath { get; set; }
+
+		[Required]
+		public string NUnitConsolePath { get; set; }
+
 		public override bool Execute()
 		{
 			try
 			{
-				var gen = new CollectTargets(Log);
+				var gen = new CollectTargets(Log, TimeoutValuesFilePath, NUnitConsolePath);
 				gen.Generate();
 				return true;
 			}


### PR DESCRIPTION
- TimeoutValuesFilePath: allows to see in build file that TestTimeoutValues.xml file is actually used somewhere
- NUnitConsolePath: path to NUnit3 console exe
- also use NUnit 3