### PR TITLE
Add Make.Macros to pass additional options 

### DIFF
--- a/SIL.FwBuildTasks/Make.cs
+++ b/SIL.FwBuildTasks/Make.cs
@@ -45,6 +45,11 @@ namespace FwBuildTasks
 		public string Target { get; set; }
 
 		/// <summary>
+		/// Gets or sets additional macros passed to make
+		/// </summary>
+		public string Macros { get; set; }
+
+		/// <summary>
 		/// Gets the build "type" (d, r, p, b).
 		/// This can be derived from the build configuration.
 		/// </summary>
@@ -125,6 +130,11 @@ namespace FwBuildTasks
 				bldr.AppendSwitchIfNotNull("BUILD_TYPE=", BuildType);
 				bldr.AppendSwitchIfNotNull("BUILD_ROOT=", BuildRoot);
 				bldr.AppendSwitchIfNotNull("BUILD_ARCH=", BuildArch);
+				if (!string.IsNullOrEmpty(Macros))
+				{
+					bldr.AppendTextUnquoted(" ");
+					bldr.AppendTextUnquoted(Macros);
+				}
 				bldr.AppendSwitchIfNotNull("-C ", WorkingDirectory);
 				bldr.AppendSwitchIfNotNull("-f ", Makefile);
 				bldr.AppendSwitch(string.IsNullOrEmpty(Target) ? "all" : Target);
@@ -136,6 +146,11 @@ namespace FwBuildTasks
 				bldr.AppendSwitchIfNotNull("BUILD_TYPE=", BuildType);
 				bldr.AppendSwitchIfNotNull("BUILD_ROOT=", BuildRoot);
 				bldr.AppendSwitchIfNotNull("BUILD_ARCH=", BuildArch);
+				if (!string.IsNullOrEmpty(Macros))
+				{
+					bldr.AppendTextUnquoted(" ");
+					bldr.AppendTextUnquoted(Macros);
+				}
 				bldr.AppendSwitchIfNotNull("/f ", Makefile);
 				if (!string.IsNullOrEmpty(Target))
 					bldr.AppendSwitch(Target);

--- a/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
+++ b/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
+    <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
     <Reference Include="System.IO.Compression" />

--- a/SIL.FwBuildTasksTests/MakeTests.cs
+++ b/SIL.FwBuildTasksTests/MakeTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.IO;
+using FwBuildTasks;
+using NUnit.Framework;
+using SIL.FieldWorks.Build.Tasks.Localization;
+
+namespace SIL.FieldWorks.Build.Tasks
+{
+	[TestFixture]
+	public class MakeTests
+	{
+		private class MakeSubclass : Make
+		{
+			public string GetCommandLine()
+			{
+				return GenerateCommandLineCommands();
+			}
+		}
+
+		private TestBuildEngine _tbi;
+
+		[SetUp]
+		public void TestSetup()
+		{
+			_tbi = new TestBuildEngine();
+		}
+
+		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows specific test")]
+		public void CommandLine_NoAdditionalMacros_Windows()
+		{
+			var sut = new MakeSubclass
+			{
+				BuildEngine = _tbi,
+				Makefile = "MyMakefile"
+			};
+
+			Assert.That(sut.GetCommandLine(), Is.EqualTo("/nologo BUILD_TYPE=d /f MyMakefile"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void CommandLine_NoAdditionalMacros_Linux()
+		{
+			var sut = new MakeSubclass
+			{
+				BuildEngine = _tbi,
+				Makefile = "MyMakefile"
+			};
+
+			Assert.That(sut.GetCommandLine(), Is.EqualTo("BUILD_TYPE=d -f MyMakefile all"));
+		}
+
+		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows specific test")]
+		public void CommandLine_AdditionalMacros_Windows()
+		{
+			var sut = new MakeSubclass
+			{
+				BuildEngine = _tbi,
+				Makefile = "MyMakefile",
+				Macros = "A=B C=D"
+			};
+
+			Assert.That(sut.GetCommandLine(), Is.EqualTo("/nologo BUILD_TYPE=d A=B C=D /f MyMakefile"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void CommandLine_AdditionalMacros_Linux()
+		{
+			var sut = new MakeSubclass
+			{
+				BuildEngine = _tbi,
+				Makefile = "MyMakefile",
+				Macros = "A=B C=D"
+			};
+
+			Assert.That(sut.GetCommandLine(), Is.EqualTo("BUILD_TYPE=d A=B C=D -f MyMakefile"));
+		}
+
+	}
+}

--- a/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
+++ b/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7" PrivateAssets="All" />
+    <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />


### PR DESCRIPTION
This change adds a Macros attribute to the Make task which allows to pass additional options, e.g. setting a macro.