### PR TITLE
Modernize package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Create nuget packages
 - Projects that require access to the classes defined in FwBuildTasks should import the
   `SIL.FwBuildTasks.Lib` nuget package, all others `SIL.FwBuildTasks`.
+- Build for Netstandard 2.0
+
 
 ### Fixed
 

--- a/SIL.FwBuildTasks.Lib/SIL.FwBuildTasks.Lib.csproj
+++ b/SIL.FwBuildTasks.Lib/SIL.FwBuildTasks.Lib.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.4.0" PrivateAssets="All" />
   </ItemGroup>

--- a/SIL.FwBuildTasks.Lib/SIL.FwBuildTasks.Lib.csproj
+++ b/SIL.FwBuildTasks.Lib/SIL.FwBuildTasks.Lib.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>module</OutputType>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>SIL.FieldWorks.Build.Tasks</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Description>Additional msbuild tasks for FieldWorks. Usually you won't need this package. Use it if you write tasks or classes that derive from FwBuildTasks.</Description>
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>FieldWorks</Product>
-    <Copyright>Copyright © 2010-2020 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2021 SIL International</Copyright>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/SIL.FwBuildTasks</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/SIL.FwBuildTasks/Clouseau.cs
+++ b/SIL.FwBuildTasks/Clouseau.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.Remoting.Contexts;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 

--- a/SIL.FwBuildTasks/RegFree.cs
+++ b/SIL.FwBuildTasks/RegFree.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
-using System.Windows.Forms;
 using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
+++ b/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />

--- a/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
+++ b/SIL.FwBuildTasks/SIL.FwBuildTasks.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>SIL.FieldWorks.Build.Tasks</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Description>Additional msbuild tasks for FieldWorks</Description>
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>FieldWorks</Product>
-    <Copyright>Copyright © 2010-2020 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2021 SIL International</Copyright>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/SIL.FwBuildTasks</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -32,8 +32,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
     <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.4.0" PrivateAssets="All" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
+++ b/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
@@ -8,7 +8,7 @@
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>FieldWorks</Product>
-    <Copyright>Copyright © 2010-2020 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2021 SIL International</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/SIL.FwBuildTasks</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -30,6 +30,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="SIL.TestUtilities" Version="8.0.0-beta0264" />

--- a/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
+++ b/SIL.FwBuildTasksTests/SIL.FwBuildTasksTests.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/SIL.FwBuildTasks/blob/main/CHA
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.5.1" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.4.0" PrivateAssets="All" />


### PR DESCRIPTION
- Build for Netstandard 2.0
- Use GitVersion.MsBuild instead of deprecated GitVersionTask

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.fwbuildtasks/20)
<!-- Reviewable:end -->
